### PR TITLE
[Test] Add create account service test

### DIFF
--- a/src/main/java/org/scoula/backend/global/config/WebSecurityConfig.java
+++ b/src/main/java/org/scoula/backend/global/config/WebSecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -32,6 +33,11 @@ public class WebSecurityConfig implements WebMvcConfigurer {
 
     @Value("${chrome.extension.id}")
     private String chromeExtensionId;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {

--- a/src/main/java/org/scoula/backend/member/controller/response/LoginResponseDto.java
+++ b/src/main/java/org/scoula/backend/member/controller/response/LoginResponseDto.java
@@ -1,14 +1,18 @@
 package org.scoula.backend.member.controller.response;
 
+import java.math.BigDecimal;
+
 import lombok.Getter;
 
 @Getter
 public class LoginResponseDto {
     private final Long userId;
     private final String username;
+    private final BigDecimal balance;
 
-    public LoginResponseDto(Long userId, String username) {
+    public LoginResponseDto(Long userId, String username, BigDecimal balance) {
         this.userId = userId;
         this.username = username;
+        this.balance = balance;
     }
 }

--- a/src/main/java/org/scoula/backend/member/domain/Member.java
+++ b/src/main/java/org/scoula/backend/member/domain/Member.java
@@ -2,6 +2,8 @@ package org.scoula.backend.member.domain;
 
 import static jakarta.persistence.CascadeType.*;
 
+import java.math.BigDecimal;
+
 import org.scoula.backend.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -57,6 +59,10 @@ public class Member extends BaseEntity {
 
 	public void createAccount() {
 		this.account = new Account(this);
+	}
+
+	public BigDecimal getMemberBalance() {
+		return this.account.getBalance();
 	}
 
 	private String parseUsernameFromEmail(String email) {

--- a/src/main/java/org/scoula/backend/member/repository/impls/MemberRepositoryImpl.java
+++ b/src/main/java/org/scoula/backend/member/repository/impls/MemberRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.scoula.backend.member.repository.impls;
 
+import java.util.Optional;
+
 import org.scoula.backend.member.domain.Member;
 import org.scoula.backend.member.exception.MemberNotFoundException;
 import org.scoula.backend.member.repository.MemberJpaRepository;
@@ -13,8 +15,24 @@ public class MemberRepositoryImpl {
 
 	private final MemberJpaRepository memberJpaRepository;
 
+	// Get: 존재하지 않으면 예외 발생
+	// Find: 존재하지 않으면 Optional.empty() 반환
+
 	public Member getByUsername(final String username) {
 		return memberJpaRepository.findByUsername(username)
 				.orElseThrow(MemberNotFoundException::new);
+	}
+
+	public Member getByEmail(final String email) {
+		return memberJpaRepository.findByEmail(email)
+				.orElseThrow(MemberNotFoundException::new);
+	}
+
+	public Optional<Member> findByEmail(final String email) {
+		return memberJpaRepository.findByEmail(email);
+	}
+
+	public Member save(final Member member) {
+		return memberJpaRepository.save(member);
 	}
 }

--- a/src/main/java/org/scoula/backend/member/service/GoogleOAuthService.java
+++ b/src/main/java/org/scoula/backend/member/service/GoogleOAuthService.java
@@ -10,6 +10,9 @@ import org.scoula.backend.member.domain.Member;
 import org.scoula.backend.member.domain.MemberRoleEnum;
 import org.scoula.backend.member.repository.AccountJpaRepository;
 import org.scoula.backend.member.repository.MemberJpaRepository;
+import org.scoula.backend.member.repository.impls.AccountRepositoryImpl;
+import org.scoula.backend.member.repository.impls.MemberRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -21,13 +24,11 @@ import java.math.BigDecimal;
 import java.net.URI;
 
 @Service
-@RequiredArgsConstructor
 public class GoogleOAuthService {
-    private final MemberJpaRepository memberRepository;
-    private final AccountJpaRepository accountRepository;
+    private final MemberRepositoryImpl memberRepository;
+    private final AccountRepositoryImpl accountRepository;
     private final JwtUtil jwtUtil;
-
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     @Value("${google.client.id}")
     private String clientId;
@@ -43,6 +44,13 @@ public class GoogleOAuthService {
 
     @Value("${google.userinfo.uri}")
     private String userInfoUri;
+
+    public GoogleOAuthService(MemberRepositoryImpl memberRepository, AccountRepositoryImpl accountRepository, JwtUtil jwtUtil, RestTemplate restTemplate) {
+        this.memberRepository = memberRepository;
+        this.accountRepository = accountRepository;
+        this.jwtUtil = jwtUtil;
+        this.restTemplate = restTemplate;
+    }
 
     public LoginResponseDto googleLogin(String code, HttpServletResponse response) throws IOException {
         // Step 1: Exchange code for access token
@@ -71,7 +79,7 @@ public class GoogleOAuthService {
         // Step 4: Generate JWT token
         String jwtToken = jwtUtil.createToken(user.getUsername());
         response.addHeader("Authorization",  jwtToken);
-        return new LoginResponseDto(user.getId(),username);
+        return new LoginResponseDto(user.getId(),username, user.getMemberBalance());
     }
 
     private String getAccessToken(String code) {

--- a/src/test/java/org/scoula/backend/member/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/org/scoula/backend/member/service/GoogleOAuthServiceTest.java
@@ -1,4 +1,118 @@
 package org.scoula.backend.member.service;
 
-public class GoogleOAuthServiceTest {
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.scoula.backend.global.jwt.JwtUtil;
+import org.scoula.backend.member.controller.response.LoginResponseDto;
+import org.scoula.backend.member.domain.Account;
+import org.scoula.backend.member.domain.Member;
+import org.scoula.backend.member.repository.impls.AccountRepositoryImpl;
+import org.scoula.backend.member.repository.impls.MemberRepositoryImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuthServiceTest {
+
+    @InjectMocks
+    private GoogleOAuthService googleOAuthService;
+
+    @Mock
+    private MemberRepositoryImpl memberRepository;
+
+	@Mock
+	private AccountRepositoryImpl accountRepository;
+
+	@Mock
+    private JwtUtil jwtUtil;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+    private RestTemplate restTemplate;  // RestTemplate를 테스트 클래스에서 모킹
+
+	private final String email = "test@example.com";
+
+    @BeforeEach
+    void setUp() {
+        // 필수 필드 값 설정
+        ReflectionTestUtils.setField(googleOAuthService, "tokenUri", "https://test.com/token");
+        ReflectionTestUtils.setField(googleOAuthService, "clientId", "test-client-id");
+        ReflectionTestUtils.setField(googleOAuthService, "clientSecret", "test-client-secret");
+        ReflectionTestUtils.setField(googleOAuthService, "redirectUri", "http://localhost:8080/callback");
+		ReflectionTestUtils.setField(googleOAuthService, "userInfoUri", "https://test.com/userinfo");
+     
+        // 1. Access Token 응답 모킹
+        JsonNode tokenResponse = mock(JsonNode.class);
+        when(tokenResponse.get("access_token")).thenReturn(new TextNode("mocked_access_token"));
+        when(restTemplate.postForEntity(
+            any(URI.class),
+            isNull(),
+            eq(JsonNode.class)
+        )).thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+        // 2. User Info 응답 모킹
+        JsonNode userInfoResponse = mock(JsonNode.class);
+        when(userInfoResponse.get("email")).thenReturn(new TextNode(email));
+        when(userInfoResponse.get("sub")).thenReturn(new TextNode("123456789"));
+
+        // exchange 메서드 모킹
+        when(restTemplate.exchange(
+            anyString(),                // userInfoUri
+            eq(HttpMethod.GET),        // HTTP 메서드
+            argThat(request -> {       // HttpEntity 매칭
+                HttpHeaders headers = request.getHeaders();
+                return headers.containsKey("Authorization") &&
+                    headers.getFirst("Authorization").startsWith("Bearer ");
+            }),
+            eq(JsonNode.class)         // 응답 타입
+        )).thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+    
+    }
+
+    @Test
+	@DisplayName("Create account when new user created")
+    void whenNewUserCreated_thenAccountShouldBeCreated() throws IOException {
+		// given
+		String username = email.split("@")[0];
+		BigDecimal expectedBalance = new BigDecimal(100000000);
+
+		// Member 저장 모킹
+		when(memberRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+		when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> {
+			Member savedMember = invocation.getArgument(0);  // 저장하려는 Member 객체
+			ReflectionTestUtils.setField(savedMember, "id", 1L);  // ID 설정
+			return savedMember;  // 저장된 Member 반환
+		});
+
+		// when
+		LoginResponseDto result = googleOAuthService.googleLogin("test-code", response);
+
+		// then
+		assertThat(result.getUsername()).isEqualTo(username);
+		assertThat(result.getBalance()).isEqualTo(expectedBalance);
+	}
 }


### PR DESCRIPTION
### 💡 I resolved the following issues:

#25 

<br><br>

### 💡 Code has been added while handling the issue:

- Added `GoogleOAuthServiceTest` for testing Google OAuth login functionality
- Updated `LoginResponseDto` to include "balance"
- Modified service code to enable RestTemplate mocking for testing
- Fixed repository connections (changed from using direct JpaRepository to using repository implementations)
    - MemberJPARepository -> MemberRepositoryImpl
    - AccountJPARepository -> AccountRepositoryImpl 
- Added proper mocking setup for member creation and account initialization

<br><br>

### 💡 Follow-up tasks are needed:



<br><br>

### 💡 The following resources might be helpful:



<br><br>

### ✅ Self Checklist

- [x] I am submitting this PR to the correct branch according to our branching strategy. (Not to master/main)
- [x] My commit messages follow the convention.
- [x] The modified code does not generate any compiler/browser warnings/errors.
- [x] The modified code passes all existing tests.
- [x] I have reviewed whether test additions are necessary and added them if needed.
- [x] I have reviewed whether documentation updates are necessary and updated them if needed.
