### PR TITLE
[Feat] Add logic to ensure that the same user’s orders are not matched

### DIFF
--- a/src/main/java/org/scoula/backend/order/service/OrderBookService.java
+++ b/src/main/java/org/scoula/backend/order/service/OrderBookService.java
@@ -199,6 +199,12 @@ public class OrderBookService {
 	private void matchOrders(final Queue<Order> existingOrders, final Order incomingOrder) {
 		while (!existingOrders.isEmpty() && incomingOrder.getRemainingQuantity().compareTo(BigDecimal.ZERO) > 0) {
 			final Order existingOrder = existingOrders.peek();
+
+			// 동일 유저 주문 체결 방지
+			if (incomingOrder.getAccount().getMember().equals(existingOrder.getAccount().getMember())) {
+				break;
+			}
+
         	final BigDecimal matchedQuantity = incomingOrder.getRemainingQuantity()
 				.min(existingOrder.getRemainingQuantity());
 			final BigDecimal matchPrice = existingOrder.getPrice(); // 체결 가격은 항상 기존 주문 가격


### PR DESCRIPTION
### 💡 I resolved the following issues:

- #60 
- Added logic to prevent orders from being matched if they belong to the same user. This ensures that a user's orders are not executed against each other, maintaining the integrity of the order matching process.

<br><br>

### 💡 Code has been added while handling the issue:

```
// 동일 유저 주문 체결 방지
if (incomingOrder.getAccount().getMember().equals(existingOrder.getAccount().getMember())) {
    break;
}
```

<br><br>

### 💡 Follow-up tasks are needed:


<br><br>

### 💡 The following resources might be helpful:


<br><br>

### ✅ Self Checklist

- [x] I am submitting this PR to the correct branch according to our branching strategy. (Not to master/main)
- [x] My commit messages follow the convention.
- [x] The modified code does not generate any compiler/browser warnings/errors.
- [x] The modified code passes all existing tests.
- [x] I have reviewed whether test additions are necessary and added them if needed.
- [x] I have reviewed whether documentation updates are necessary and updated them if needed.
